### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/backend/utils/crud.py
+++ b/backend/utils/crud.py
@@ -9,7 +9,13 @@ import logging
 logger = logging.getLogger(__name__)
 
 def log_db_operation(operation: str, table: str, record_id: uuid.UUID, user_email: str, additional_info: Optional[Dict] = None):
-    """Log database operations with user information"""
+    """
+    Log database operations with user information.
+
+    SECURITY: Never include sensitive or user-supplied data (such as API key values
+    or names/labels provided by users) in additional_info.
+    Only pass pre-reviewed, non-sensitive information for audit logging.
+    """
     # Sanitize user input to prevent log injection
     safe_user_domain = 'unknown'
     if user_email and '@' in user_email:
@@ -700,7 +706,8 @@ async def create_api_key(db: AsyncSession, api_key: schemas.ApiKeyCreate, user_i
     await db.commit()
     await db.refresh(db_api_key)
     
-    log_db_operation("CREATE", "api_keys", db_api_key.id, created_by or "system", {"name": api_key.name, "user_id": str(user_id)})
+    # For security, do not log API key name or other user-supplied details.
+    log_db_operation("CREATE", "api_keys", db_api_key.id, created_by or "system", {"user_id": str(user_id)})
     return db_api_key
 
 async def update_api_key_last_used(db: AsyncSession, api_key_id: uuid.UUID) -> None:


### PR DESCRIPTION
Potential fix for [https://github.com/sandialabs/VISTA/security/code-scanning/3](https://github.com/sandialabs/VISTA/security/code-scanning/3)

To fix this problem, we must ensure that no sensitive data or untrusted user-supplied content is logged in clear text. That means:
- When logging database operations regarding API keys, never include the API key value, the hash, or any untrusted fields such as the key name verbatim without review.
- Only include minimal, non-sensitive and non-identifying fields, such as resource IDs or static information, in log records.
- For the `create_api_key` and `deactivate_api_key` operations, sanitize or eliminate logging of user-supplied fields in `additional_info` (e.g., do not log `api_key.name`). Log only safe, pre-reviewed constants such as the user ID (which is already a UUID and not PII), and the fact an operation occurred.
  
**Required changes:**
- In `crud.create_api_key`: update the call to `log_db_operation` to *not* include the user-supplied API key name. Log only the `user_id` (already a UUID), or remove `additional_info` entirely.
- In `crud.deactivate_api_key`: the call to `log_db_operation` only logs `{ "deactivated": True }`, which is fine.
- In `log_db_operation`: optionally, add a security comment to indicate that `additional_info` must never include sensitive/user-supplied values; validate or sanitize as an extra layer if desired.

No new methods or imports are needed; the change is limited to the removal/editing of logging of untrusted content.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
