### PR TITLE
Fix eslint warning in MeasurementOverlay breaking CI build

### DIFF
--- a/frontend/src/components/MeasurementOverlay.js
+++ b/frontend/src/components/MeasurementOverlay.js
@@ -25,8 +25,7 @@ export default function MeasurementOverlay({
         displayX2: m.x2 * scaleX,
         displayY2: m.y2 * scaleY
       }));
-  // Include calibration in deps to ensure re-render when calibration changes
-  }, [measurements, naturalSize, containerSize, visibleMeasurementIds, calibration]);
+  }, [measurements, naturalSize, containerSize, visibleMeasurementIds]);
 
   // Calculate real-world distances dynamically from pixels using current calibration
   const formatDistance = (measurement) => {


### PR DESCRIPTION
## Summary

- Removes unnecessary `calibration` dependency from the `useMemo` hook in `MeasurementOverlay.js`

## Root cause

The CI/CD Pipeline fails at the "Build frontend" step because `react-scripts build` runs with `CI=true`, which treats eslint warnings as errors. The warning:

```
src/components/MeasurementOverlay.js
  Line 29:6:  React Hook useMemo has an unnecessary dependency: 'calibration'.
  Either exclude it or remove the dependency array  react-hooks/exhaustive-deps
```

The `useMemo` callback only computes display coordinates (scaling pixel positions to container size). It never references `calibration`. The `formatDistance` function that actually uses `calibration` is defined outside the memo and re-evaluates on every render naturally when the prop changes.

## Test plan

- [x] `CI=true npx react-scripts build` passes locally
- [ ] CI/CD Pipeline workflow passes after merge


Generated with [Claude Code](https://claude.com/claude-code)