### PR TITLE
Add dependency vulnerability scanning to CI

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -1,0 +1,62 @@
+name: Dependency Vulnerability Scan
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    # Run weekly on Monday at 06:00 UTC
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  python-audit:
+    name: Python dependency audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install Python dependencies
+        run: uv sync --frozen
+
+      - name: Install pip-audit
+        run: uv pip install pip-audit
+
+      - name: Run pip-audit
+        run: uv run pip-audit --strict --desc
+
+  node-audit:
+    name: Node dependency audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: |
+          cd frontend
+          npm ci --legacy-peer-deps
+
+      - name: Run npm audit
+        run: |
+          cd frontend
+          npm audit --audit-level=high


### PR DESCRIPTION
## Summary

- Adds a new GitHub Actions workflow (`dependency-scan.yml`) that audits both Python and Node dependencies for known vulnerabilities
- Python job uses `pip-audit --strict --desc` against the uv-managed dependency set
- Node job uses `npm audit --audit-level=high` against frontend dependencies
- Runs on push to main, PRs to main, and on a weekly Monday cron schedule to catch newly disclosed CVEs

## Test plan

- [ ] Verify the workflow appears in the Actions tab after merge
- [ ] Confirm the Python audit job installs dependencies via uv and runs pip-audit successfully
- [ ] Confirm the Node audit job runs npm audit against frontend dependencies
- [ ] Trigger a manual workflow run or open a test PR to validate both jobs execute and report results
- [ ] Verify the weekly cron schedule is registered correctly