### PR TITLE
Replace debug print statements with proper logging

### DIFF
--- a/backend/routers/comments.py
+++ b/backend/routers/comments.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -6,6 +7,8 @@ import utils.crud as crud
 from core import schemas
 from core.database import get_db
 from utils.dependencies import get_current_user, get_user_context, UserContext, get_image_or_403
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(
     tags=["Comments"],
@@ -18,9 +21,9 @@ async def create_comment(
     db: AsyncSession = Depends(get_db),
     user_context: UserContext = Depends(get_user_context),
 ):
-    print(f"Comment request received for image_id: {image_id}")
-    print(f"Comment text: {comment.text}")
-    print(f"Current user: {user_context.user}")
+    logger.debug("Comment request received for image_id: %s", image_id)
+    logger.debug("Comment text: %s", comment.text)
+    logger.debug("Current user: %s", user_context.user)
     
     # Check if the user has access to the image
     await get_image_or_403(image_id, db, user_context.user)
@@ -32,7 +35,7 @@ async def create_comment(
         author_id=user_context.id  # Automatically resolved ID
     )
     
-    print(f"Created comment object: {comment_create}")
+    logger.debug("Created comment object: %s", comment_create)
     
     # Create the comment with automatic user context
     return await crud.create_comment(db=db, comment=comment_create, created_by=user_context.email)

--- a/backend/routers/image_classes.py
+++ b/backend/routers/image_classes.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -7,6 +8,8 @@ from core import schemas
 from core.database import get_db
 from core.group_auth_helper import is_user_in_group
 from utils.dependencies import get_current_user, get_project_or_403, get_image_or_403
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(
     tags=["Image Classes"],
@@ -118,8 +121,8 @@ async def classify_image(
     db: AsyncSession = Depends(get_db),
     current_user: schemas.User = Depends(get_current_user),
 ):
-    print(f"Classification request received for image_id: {image_id}")
-    print(f"Request body: {classification}")
+    logger.debug("Classification request received for image_id: %s", image_id)
+    logger.debug("Request body: %s", classification)
     
     # Check if the user has access to the image
     db_image = await get_image_or_403(image_id, db, current_user)
@@ -127,9 +130,7 @@ async def classify_image(
     # Ensure the image_id in the path matches the one in the request body
     # Convert both to strings for comparison to handle different UUID object types
     if str(image_id) != str(classification.image_id):
-        print(f"Image ID mismatch: path={image_id}, body={classification.image_id}")
-        print(f"Types: path={type(image_id)}, body={type(classification.image_id)}")
-        print(f"String comparison: {str(image_id)} vs {str(classification.image_id)}")
+        logger.warning("Image ID mismatch: path=%s, body=%s", image_id, classification.image_id)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Image ID in the path must match the image_id in the request body. Path: {image_id}, Body: {classification.image_id}",
@@ -166,7 +167,7 @@ async def classify_image(
         classification.created_by_id = db_user.id
     
     # Log the final classification object before saving
-    print(f"Final classification object to save: {classification}")
+    logger.debug("Final classification object to save: %s", classification)
     
     # Create the classification
     return await crud.create_image_classification(db=db, classification=classification)

--- a/backend/routers/images.py
+++ b/backend/routers/images.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 import io
 import os
@@ -137,7 +138,7 @@ async def list_images_in_project(
                     continue
                 response_images.append(to_data_instance_schema(img))
             except Exception as e:
-                print(f"Error serializing image {img.id}: {e}")
+                logger.warning("Error serializing image %s: %s", img.id, e)
                 # Skip this image but continue processing others
                 continue
     
@@ -652,7 +653,7 @@ async def update_image_metadata(
             updated_at=db_image.updated_at,
         )
     except Exception as e:
-        print(f"Error building DataInstance response: {e}")
+        logger.error("Error building DataInstance response: %s", e)
         raise
 
 @router.delete("/images/{image_id}/metadata/{key}", response_model=schemas.DataInstance, status_code=status.HTTP_200_OK)
@@ -715,5 +716,5 @@ async def delete_image_metadata(
             updated_at=db_image.updated_at,
         )
     except Exception as e:
-        print(f"Error building DataInstance response: {e}")
+        logger.error("Error building DataInstance response: %s", e)
         raise

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -9,26 +9,17 @@ const ImageView = lazy(() => import('./ImageView'));
 const ApiKeys = lazy(() => import('./ApiKeys'));
 const ProjectReport = lazy(() => import('./components/ProjectReport'));
 
-// Debug counter to track renders
-let renderCount = 0;
 
 // Create a separate component for the modal form
 const CreateProjectModal = memo(function CreateProjectModal({ onClose, onSubmit, currentUser }) {
-  console.log("Modal render count:", ++renderCount);
-  
   // Use refs for uncontrolled inputs
   const nameInputRef = useRef(null);
   const descriptionInputRef = useRef(null);
   const groupIdInputRef = useRef(null);
   
-  // Track focus state for debugging
-  const [focusState, setFocusState] = useState('none');
-  
   // Handle form submission
   const handleSubmit = (e) => {
     e.preventDefault();
-    console.log("Form submitted");
-    
     // Get values directly from refs
     const newProject = {
       name: nameInputRef.current.value,
@@ -39,31 +30,11 @@ const CreateProjectModal = memo(function CreateProjectModal({ onClose, onSubmit,
     onSubmit(newProject);
   };
   
-  // Debug focus events
-  const handleFocus = (fieldName) => {
-    console.log(`Focus on: ${fieldName}`);
-    setFocusState(fieldName);
-  };
-  
-  const handleBlur = (fieldName) => {
-    console.log(`Blur from: ${fieldName}`);
-    if (focusState === fieldName) {
-      setFocusState('none');
-    }
-  };
-  
-  // Fetch available groups when component mounts
+  // Focus the name input when modal opens
   useEffect(() => {
-    console.log("Modal component mounted");
-    
-    // Focus the name input when modal opens
     if (nameInputRef.current) {
       nameInputRef.current.focus();
     }
-    
-    return () => {
-      console.log("Modal component unmounted");
-    };
   }, []);
   
   return (
@@ -81,8 +52,6 @@ const CreateProjectModal = memo(function CreateProjectModal({ onClose, onSubmit,
                 type="text" 
                 id="name" 
                 ref={nameInputRef}
-                onFocus={() => handleFocus('name')}
-                onBlur={() => handleBlur('name')}
                 required
                 placeholder="Enter a descriptive project name"
                 className="form-control"
@@ -98,8 +67,6 @@ const CreateProjectModal = memo(function CreateProjectModal({ onClose, onSubmit,
                 id="description" 
                 rows="3"
                 ref={descriptionInputRef}
-                onFocus={() => handleFocus('description')}
-                onBlur={() => handleBlur('description')}
                 placeholder="Describe what this project is for..."
                 className="form-control"
               ></textarea>
@@ -114,8 +81,6 @@ const CreateProjectModal = memo(function CreateProjectModal({ onClose, onSubmit,
                 type="text" 
                 id="meta_group_id" 
                 ref={groupIdInputRef}
-                onFocus={() => handleFocus('groupId')}
-                onBlur={() => handleBlur('groupId')}
                 required
                 placeholder="Enter the group ID you have access to"
                 className="form-control"
@@ -236,12 +201,8 @@ function App() {
       });
   }, []); // Empty dependency array means this effect runs once on mount
 
-  // Log component renders for debugging
-  console.log("App render count:", ++renderCount);
-  
   // Handle project creation form submission
   const handleCreateProject = useCallback((projectData) => {
-    console.log("Creating project:", projectData);
     setLoading(true);
     
     fetch('/api/projects/', {
@@ -264,7 +225,6 @@ function App() {
         return response.json();
       })
       .then(data => {
-        console.log("Project created successfully:", data);
         // Add the new project to the projects list
         setProjects(prev => [...prev, data]);
         // Close modal


### PR DESCRIPTION
## Summary

- Replace `print()` calls in backend routers (`image_classes.py`, `comments.py`, `images.py`) with structured `logging` module calls at appropriate levels (debug, warning, error)
- Remove debug render counter, focus/blur event tracking, and console.log statements from frontend `App.js`
- All other backend modules already use the logging module; these three routers were the only holdouts

Addresses #30.

## Test plan

- [ ] Verify all 170 backend tests pass (export tests excluded due to pre-existing openpyxl dependency issue)
- [ ] Confirm no `print()` statements remain in the three modified backend router files
- [ ] Confirm no debug console.log/renderCount artifacts remain in App.js
- [ ] Verify the app loads and functions normally with DEBUG logging enabled