### PR TITLE
Fail-closed group-auth backend (C1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,21 @@ CHECK_MOCK_MEMBERSHIP=true
 MOCK_USER_EMAIL=test@example.com
 MOCK_USER_GROUPS_JSON='["admin-group", "data-scientists", "project-alpha-group", "testgroup"]'
 
+# Deployment Environment: development | staging | production
+# When set to "production", the app refuses to start with DEBUG=true,
+# SKIP_HEADER_CHECK=true, VISTA_AUTH_BACKEND=demo, or a missing
+# PROXY_SHARED_SECRET.
+ENV=development
+
+# Group Authorization Backend (REQUIRED -- fail-closed by default)
+#   demo   -- hardcoded example mapping in core.group_auth. Development
+#             and automated tests only; refused when ENV=production.
+#   custom -- integrator has replaced core.group_auth._check_group_membership
+#             with a real auth system (LDAP, OIDC, etc.). Startup self-test
+#             verifies the stub was replaced and denies demo emails.
+# If unset or set to any other value, the app refuses to start.
+VISTA_AUTH_BACKEND=demo
+
 # Security Configuration
 SECURITY_NOSNIFF_ENABLED=true
 SECURITY_XFO_ENABLED=true

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -132,6 +132,8 @@ jobs:
           -e FAST_TEST_MODE=true \
           -e DEBUG=true \
           -e SKIP_HEADER_CHECK=true \
+          -e ENV=development \
+          -e VISTA_AUTH_BACKEND=demo \
           -e POSTGRES_USER=postgres \
           -e POSTGRES_PASSWORD=postgres \
           -e POSTGRES_DB=postgres \
@@ -170,6 +172,8 @@ jobs:
           -e FAST_TEST_MODE=true \
           -e DEBUG=true \
           -e SKIP_HEADER_CHECK=true \
+          -e ENV=development \
+          -e VISTA_AUTH_BACKEND=demo \
           -e POSTGRES_USER=postgres \
           -e POSTGRES_PASSWORD=postgres \
           -e POSTGRES_DB=postgres \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,6 +184,13 @@ In debug/test mode (`DEBUG=true` or `SKIP_HEADER_CHECK=true`), the dependency fa
 - **Group-Based Access**: Projects belong to groups (`meta_group_id`), users must be members to access
 - **API Keys**: Alternative authentication via `ApiKey` model for programmatic access
 
+**Group-auth backend (fail-closed).** `core/group_auth.py:_check_group_membership` raises `NotImplementedError` by default. Integrators MUST set `VISTA_AUTH_BACKEND`:
+
+- `demo` -- hardcoded example email/group mapping. Development and tests only; refused when `ENV=production`.
+- `custom` -- integrator has replaced `_check_group_membership` with a real auth-system lookup.
+
+Startup calls `run_auth_startup_self_test()` and `settings.validate_production_safety()`. Startup fails if: `VISTA_AUTH_BACKEND` is unset or unknown; `ENV=production` with `DEBUG=true`, `SKIP_HEADER_CHECK=true`, `VISTA_AUTH_BACKEND=demo`, or missing `PROXY_SHARED_SECRET`; or a non-demo backend still grants any of the hardcoded demo emails (`admin@example.com`, `scientist@example.com`, `user@example.com`) access to the demo groups.
+
 ### Caching Strategy
 
 The application implements multi-layer caching for performance:

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -123,6 +123,8 @@ class Settings(BaseSettings):
             errors.append("DEBUG=true is not allowed when ENV=production")
         if self.SKIP_HEADER_CHECK:
             errors.append("SKIP_HEADER_CHECK=true is not allowed when ENV=production")
+        if self.FAST_TEST_MODE:
+            errors.append("FAST_TEST_MODE=true is not allowed when ENV=production")
         if (self.VISTA_AUTH_BACKEND or "").strip().lower() == "demo":
             errors.append(
                 "VISTA_AUTH_BACKEND=demo is not allowed when ENV=production. "

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -8,6 +8,18 @@ class Settings(BaseSettings):
     APP_NAME: str = "Data Management API"
     DEBUG: bool = False
     PORT: int = 8000
+    # Deployment environment: "development", "staging", or "production".
+    # When set to "production", the app refuses to start with DEBUG=true or
+    # SKIP_HEADER_CHECK=true, or with VISTA_AUTH_BACKEND=demo.
+    ENV: str = "development"
+    # Group-auth backend selector. Must be set explicitly to enable group
+    # membership checks. Supported values:
+    #   - "demo": hardcoded example email->group mapping. Development/testing only.
+    #   - "custom": a project-specific implementation is wired into
+    #     core.group_auth._check_group_membership. Fail-closed by default.
+    # Any other value (including unset) causes _check_group_membership to
+    # raise NotImplementedError, preventing accidental prod-bypass.
+    VISTA_AUTH_BACKEND: Optional[str] = None
     # When enabled, avoid any external calls and heavy startup work (for tests)
     FAST_TEST_MODE: bool = False
     SKIP_HEADER_CHECK: bool = False
@@ -91,6 +103,41 @@ class Settings(BaseSettings):
     def MOCK_USER_GROUPS(self):
         import json
         return json.loads(self.MOCK_USER_GROUPS_JSON)
+
+    @property
+    def is_production(self) -> bool:
+        return (self.ENV or "").strip().lower() == "production"
+
+    def validate_production_safety(self) -> None:
+        """Refuse to run in production with unsafe debug/bypass flags or
+        a demo auth backend. Raises RuntimeError with an explicit message.
+
+        Called from application startup; kept as a method (not a field
+        validator) so tests can monkey-patch individual flags without
+        tripping startup-time checks.
+        """
+        if not self.is_production:
+            return
+        errors = []
+        if self.DEBUG:
+            errors.append("DEBUG=true is not allowed when ENV=production")
+        if self.SKIP_HEADER_CHECK:
+            errors.append("SKIP_HEADER_CHECK=true is not allowed when ENV=production")
+        if (self.VISTA_AUTH_BACKEND or "").strip().lower() == "demo":
+            errors.append(
+                "VISTA_AUTH_BACKEND=demo is not allowed when ENV=production. "
+                "Set VISTA_AUTH_BACKEND=custom and implement "
+                "core.group_auth._check_group_membership."
+            )
+        if not self.PROXY_SHARED_SECRET:
+            errors.append(
+                "PROXY_SHARED_SECRET must be set when ENV=production"
+            )
+        if errors:
+            raise RuntimeError(
+                "Refusing to start in production with unsafe config:\n  - "
+                + "\n  - ".join(errors)
+            )
 
     def patch(self, updates: dict):
         """Return a shallow patched copy of settings with provided overrides.

--- a/backend/core/group_auth.py
+++ b/backend/core/group_auth.py
@@ -1,7 +1,14 @@
 """
 Core group authorization function.
 Single source of truth for group membership checks.
-Companies should replace the _check_group_membership function with their real auth system.
+
+This module is fail-closed by default: ``_check_group_membership`` raises
+``NotImplementedError`` unless ``VISTA_AUTH_BACKEND`` is explicitly set.
+
+Companies integrating VISTA should replace ``_check_group_membership`` with
+their real auth system (LDAP, OIDC, etc.) and set ``VISTA_AUTH_BACKEND=custom``.
+The built-in ``demo`` backend is for development and automated tests only and
+is refused in production (see ``Settings.validate_production_safety``).
 """
 
 import logging
@@ -11,36 +18,52 @@ from .config import settings
 logger = logging.getLogger(__name__)
 
 
+# Hardcoded demo emails that must never resolve as members in a non-demo
+# backend. Used by the startup self-test.
+_DEMO_EMAILS = (
+    "admin@example.com",
+    "scientist@example.com",
+    "user@example.com",
+)
+
+
 def is_user_in_group(user_email: str, group_id: str) -> bool:
     """
     Single source of truth for group membership checks.
-    Companies should customize the _check_group_membership function below.
-    
+
     Args:
         user_email: The user's email address (already validated by middleware)
         group_id: The group ID to check membership for
-        
+
     Returns:
         True if user is in the group, False otherwise
     """
     if not user_email or not group_id:
         return False
-    
-    # In debug/test mode, always allow access
+
+    # Debug/test bypass: allow access when DEBUG or SKIP_HEADER_CHECK is set,
+    # but only outside production. ``validate_production_safety`` refuses to
+    # start the app if production has these flags on, so reaching this branch
+    # in production would indicate tampering -- fail closed.
     if settings.DEBUG or settings.SKIP_HEADER_CHECK:
-        # Sanitize user input for logs to prevent injection
+        if settings.is_production:
+            logger.error(
+                "Refusing DEBUG/SKIP_HEADER_CHECK bypass in production",
+                extra={"env": settings.ENV},
+            )
+            return False
         safe_user_email = user_email.replace('\n', '').replace('\r', '') if user_email else 'unknown'
         safe_group_id = group_id.replace('\n', '').replace('\r', '') if group_id else 'unknown'
         logger.debug("DEBUG MODE: Allowing user access", extra={"user": safe_user_email, "group": safe_group_id})
         return True
-    
+
     # Normalize inputs
     user_email = user_email.lower().strip()
     group_id = group_id.strip()
-    
+
     # Call the actual group membership check
     is_member = _check_group_membership(user_email, group_id)
-    
+
     # Sanitize for logging
     safe_user_email = user_email.replace('\n', '').replace('\r', '')
     safe_group_id = group_id.replace('\n', '').replace('\r', '')
@@ -48,36 +71,128 @@ def is_user_in_group(user_email: str, group_id: str) -> bool:
     return is_member
 
 
-def _check_group_membership(user_email: str, group_id: str) -> bool:
+def _demo_check_group_membership(user_email: str, group_id: str) -> bool:
+    """Hardcoded development/test mapping. NEVER call directly in production.
+
+    Enabled only when ``VISTA_AUTH_BACKEND=demo`` and the process is not
+    running with ``ENV=production``.
     """
-    Internal method to check group membership.
-    
-    **COMPANIES SHOULD REPLACE THIS FUNCTION** with their actual auth system integration.
-    
-    Examples of what to implement here:
-    - Query LDAP/Active Directory
-    - Call external auth service API  
-    - Query database with user roles
-    - Call OAuth2 userinfo endpoint
-    - Integrate with enterprise SSO system
-    
-    Args:
-        user_email: The user's email address (normalized)
-        group_id: The group ID to check membership for (normalized)
-        
-    Returns:
-        True if user is in the group, False otherwise
-    """
-    # TODO: Replace with actual auth system lookup
-    # This is just a development/demo implementation
-    
-    # For development, simple user-to-group mapping
     user_group_mapping: Dict[str, List[str]] = {
         "admin@example.com": ["admin", "data-scientists", "project-alpha-group"],
-        "scientist@example.com": ["data-scientists", "project-alpha-group"], 
+        "scientist@example.com": ["data-scientists", "project-alpha-group"],
         "user@example.com": ["project-alpha-group"],
         settings.MOCK_USER_EMAIL.lower(): settings.MOCK_USER_GROUPS,
     }
-    
     user_groups = user_group_mapping.get(user_email, [])
     return group_id in user_groups
+
+
+def _check_group_membership(user_email: str, group_id: str) -> bool:
+    """
+    Internal method to check group membership.
+
+    **Fail-closed by default.** Integrators must either:
+
+    - Set ``VISTA_AUTH_BACKEND=demo`` for local development/testing (refused
+      in production).
+    - Replace this function with a real auth-system integration and set
+      ``VISTA_AUTH_BACKEND=custom``. Examples:
+
+          * Query LDAP/Active Directory
+          * Call an external auth service API
+          * Query a database with user roles
+          * Call an OAuth2 userinfo endpoint
+
+    Args:
+        user_email: The user's email address (normalized)
+        group_id: The group ID to check membership for (normalized)
+
+    Returns:
+        True if user is in the group, False otherwise
+    """
+    backend = (settings.VISTA_AUTH_BACKEND or "").strip().lower()
+
+    if backend == "demo":
+        if settings.is_production:
+            logger.error(
+                "Refusing demo auth backend in production",
+                extra={"env": settings.ENV},
+            )
+            return False
+        return _demo_check_group_membership(user_email, group_id)
+
+    if backend == "custom":
+        # Integrators replace this branch with their real auth-system lookup.
+        # Kept as NotImplementedError so an unreplaced deployment fails
+        # closed at the first check rather than silently denying access.
+        raise NotImplementedError(
+            "VISTA_AUTH_BACKEND=custom requires replacing "
+            "core.group_auth._check_group_membership with a real auth-system "
+            "integration. See docs/production/proxy-setup.md."
+        )
+
+    raise NotImplementedError(
+        "Group authorization is not configured. Set VISTA_AUTH_BACKEND=demo "
+        "for local development, or VISTA_AUTH_BACKEND=custom and replace "
+        "core.group_auth._check_group_membership with your auth system."
+    )
+
+
+def run_auth_startup_self_test() -> None:
+    """Fail-closed startup self-test for the group-auth backend.
+
+    Called from the FastAPI lifespan on startup (outside FAST_TEST_MODE).
+    Behavior:
+
+    - If ``VISTA_AUTH_BACKEND`` is unset or unknown: raise RuntimeError.
+    - If backend == "demo" and ENV == "production": raise RuntimeError.
+    - If backend != "demo": verify that the hardcoded demo emails resolve
+      as NOT-members of the demo groups. If any demo email still grants
+      access, the integrator forgot to replace the helper -- raise.
+    """
+    backend = (settings.VISTA_AUTH_BACKEND or "").strip().lower()
+
+    if not backend:
+        raise RuntimeError(
+            "VISTA_AUTH_BACKEND is not set. Refusing to start. "
+            "Set VISTA_AUTH_BACKEND=demo for development, or "
+            "VISTA_AUTH_BACKEND=custom after replacing "
+            "core.group_auth._check_group_membership."
+        )
+
+    if backend not in ("demo", "custom"):
+        raise RuntimeError(
+            f"Unknown VISTA_AUTH_BACKEND={backend!r}. "
+            "Expected 'demo' or 'custom'."
+        )
+
+    if backend == "demo" and settings.is_production:
+        raise RuntimeError(
+            "VISTA_AUTH_BACKEND=demo is not allowed when ENV=production."
+        )
+
+    # Fail closed if the demo emails still resolve as members under a
+    # non-demo backend. This catches deployments where an integrator
+    # configured VISTA_AUTH_BACKEND=custom but either forgot to replace the
+    # stub (NotImplementedError) or replaced it with something that still
+    # grants the demo emails access.
+    if backend != "demo":
+        for email in _DEMO_EMAILS:
+            for group in ("admin", "data-scientists", "project-alpha-group"):
+                try:
+                    granted = _check_group_membership(email, group)
+                except NotImplementedError as exc:
+                    raise RuntimeError(
+                        "VISTA_AUTH_BACKEND=custom is set but "
+                        "core.group_auth._check_group_membership still "
+                        "raises NotImplementedError. Replace it with a "
+                        "real auth integration."
+                    ) from exc
+                if granted:
+                    raise RuntimeError(
+                        "Auth backend self-test failed: demo email "
+                        f"{email!r} resolved as a member of {group!r}. "
+                        "Replace core.group_auth._check_group_membership "
+                        "with a real auth integration before running "
+                        "outside demo mode."
+                    )

--- a/backend/main.py
+++ b/backend/main.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from core.database import create_db_and_tables
 from core.migrations import run_migrations  # legacy no-op
 from core.config import settings as _app_settings
+from core.group_auth import run_auth_startup_self_test
 from utils.boto3_client import boto3_client, ensure_bucket_exists
 from middleware.cors_debug import add_cors_middleware, debug_exception_middleware
 from middleware.security_headers import SecurityHeadersMiddleware
@@ -86,6 +87,11 @@ async def lifespan(app: FastAPI):
     if settings.FAST_TEST_MODE:
         logger.info("FAST_TEST_MODE enabled: skipping DB table creation and S3 bucket checks.")
     else:
+        # Fail closed on unsafe production config and on an unconfigured
+        # or stub group-auth backend. Runs before anything else so startup
+        # aborts with a clear error instead of serving requests.
+        settings.validate_production_safety()
+        run_auth_startup_self_test()
         # NOTE: Database migrations are NOT run automatically on startup.
         # Run migrations manually using: ./start.sh -m or alembic upgrade head
         logger.info("Database migrations should be run manually via './start.sh -m' or 'alembic upgrade head'")

--- a/backend/main.py
+++ b/backend/main.py
@@ -84,14 +84,15 @@ logger = setup_logging()
 async def lifespan(app: FastAPI):
     """Application lifespan manager."""
     logger.info("Application startup...")
+    # Fail closed on unsafe production config and on an unconfigured or
+    # stub group-auth backend. Runs unconditionally (including under
+    # FAST_TEST_MODE) so a production deployment cannot silently skip the
+    # guards by flipping FAST_TEST_MODE=true.
+    settings.validate_production_safety()
+    run_auth_startup_self_test()
     if settings.FAST_TEST_MODE:
         logger.info("FAST_TEST_MODE enabled: skipping DB table creation and S3 bucket checks.")
     else:
-        # Fail closed on unsafe production config and on an unconfigured
-        # or stub group-auth backend. Runs before anything else so startup
-        # aborts with a clear error instead of serving requests.
-        settings.validate_production_safety()
-        run_auth_startup_self_test()
         # NOTE: Database migrations are NOT run automatically on startup.
         # Run migrations manually using: ./start.sh -m or alembic upgrade head
         logger.info("Database migrations should be run manually via './start.sh -m' or 'alembic upgrade head'")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -17,6 +17,8 @@ os.environ["S3_SECRET_KEY"] = "test-secret"
 os.environ["S3_BUCKET"] = "test-bucket"
 os.environ["SKIP_HEADER_CHECK"] = "true"
 os.environ["DEBUG"] = "true"
+os.environ.setdefault("VISTA_AUTH_BACKEND", "demo")
+os.environ.setdefault("ENV", "development")
 from main import app
 from core.database import Base, get_db
 from core.schemas import User

--- a/backend/tests/test_auth_backend_hardening.py
+++ b/backend/tests/test_auth_backend_hardening.py
@@ -1,0 +1,165 @@
+"""Tests for the fail-closed group-auth backend hardening (issue C1).
+
+Covers:
+- ``_check_group_membership`` raises NotImplementedError unless an auth
+  backend is configured.
+- ``run_auth_startup_self_test`` refuses to start with an unconfigured or
+  stub backend, or when demo emails resolve as members.
+- ``Settings.validate_production_safety`` refuses unsafe prod config.
+"""
+
+import pytest
+from unittest.mock import patch
+
+from core.config import settings
+from core.group_auth import (
+    _check_group_membership,
+    is_user_in_group as core_is_user_in_group,
+    run_auth_startup_self_test,
+)
+
+
+class TestFailClosedByDefault:
+    def test_unconfigured_backend_raises(self):
+        with patch.object(settings, "DEBUG", False), \
+             patch.object(settings, "SKIP_HEADER_CHECK", False), \
+             patch.object(settings, "VISTA_AUTH_BACKEND", None):
+            with pytest.raises(NotImplementedError):
+                _check_group_membership("admin@example.com", "admin")
+
+    def test_unknown_backend_raises(self):
+        with patch.object(settings, "DEBUG", False), \
+             patch.object(settings, "SKIP_HEADER_CHECK", False), \
+             patch.object(settings, "VISTA_AUTH_BACKEND", "garbage"):
+            with pytest.raises(NotImplementedError):
+                _check_group_membership("admin@example.com", "admin")
+
+    def test_custom_stub_raises_not_implemented(self):
+        with patch.object(settings, "DEBUG", False), \
+             patch.object(settings, "SKIP_HEADER_CHECK", False), \
+             patch.object(settings, "VISTA_AUTH_BACKEND", "custom"):
+            with pytest.raises(NotImplementedError):
+                _check_group_membership("admin@example.com", "admin")
+
+    def test_demo_backend_works_outside_production(self):
+        with patch.object(settings, "DEBUG", False), \
+             patch.object(settings, "SKIP_HEADER_CHECK", False), \
+             patch.object(settings, "ENV", "development"), \
+             patch.object(settings, "VISTA_AUTH_BACKEND", "demo"):
+            assert _check_group_membership("admin@example.com", "admin") is True
+
+    def test_demo_backend_refused_in_production(self):
+        with patch.object(settings, "DEBUG", False), \
+             patch.object(settings, "SKIP_HEADER_CHECK", False), \
+             patch.object(settings, "ENV", "production"), \
+             patch.object(settings, "VISTA_AUTH_BACKEND", "demo"):
+            # Check via the public entry point so the production guard fires.
+            assert core_is_user_in_group("admin@example.com", "admin") is False
+
+    def test_debug_bypass_refused_in_production(self):
+        """If somehow DEBUG=true in production, the bypass still denies access."""
+        with patch.object(settings, "DEBUG", True), \
+             patch.object(settings, "ENV", "production"):
+            assert core_is_user_in_group("admin@example.com", "admin") is False
+
+
+class TestStartupSelfTest:
+    def test_unconfigured_backend_fails_startup(self):
+        with patch.object(settings, "VISTA_AUTH_BACKEND", None):
+            with pytest.raises(RuntimeError, match="VISTA_AUTH_BACKEND is not set"):
+                run_auth_startup_self_test()
+
+    def test_unknown_backend_fails_startup(self):
+        with patch.object(settings, "VISTA_AUTH_BACKEND", "bogus"):
+            with pytest.raises(RuntimeError, match="Unknown VISTA_AUTH_BACKEND"):
+                run_auth_startup_self_test()
+
+    def test_demo_in_production_fails_startup(self):
+        with patch.object(settings, "VISTA_AUTH_BACKEND", "demo"), \
+             patch.object(settings, "ENV", "production"):
+            with pytest.raises(RuntimeError, match="demo is not allowed"):
+                run_auth_startup_self_test()
+
+    def test_custom_stub_fails_startup(self):
+        with patch.object(settings, "VISTA_AUTH_BACKEND", "custom"), \
+             patch.object(settings, "ENV", "development"):
+            with pytest.raises(RuntimeError, match="still.*raises NotImplementedError"):
+                run_auth_startup_self_test()
+
+    def test_custom_insecure_fails_startup(self):
+        """If a custom backend grants demo emails access, startup fails."""
+        always_true = lambda email, group: True
+        with patch.object(settings, "VISTA_AUTH_BACKEND", "custom"), \
+             patch.object(settings, "ENV", "development"), \
+             patch("core.group_auth._check_group_membership", side_effect=always_true):
+            with pytest.raises(RuntimeError, match="self-test failed"):
+                run_auth_startup_self_test()
+
+    def test_custom_secure_passes_startup(self):
+        """A custom backend that denies demo emails passes the self-test."""
+        deny_all = lambda email, group: False
+        with patch.object(settings, "VISTA_AUTH_BACKEND", "custom"), \
+             patch.object(settings, "ENV", "development"), \
+             patch("core.group_auth._check_group_membership", side_effect=deny_all):
+            # Should not raise.
+            run_auth_startup_self_test()
+
+    def test_demo_in_development_passes_startup(self):
+        with patch.object(settings, "VISTA_AUTH_BACKEND", "demo"), \
+             patch.object(settings, "ENV", "development"):
+            run_auth_startup_self_test()
+
+
+class TestProductionSafetyValidator:
+    def test_non_production_is_noop(self):
+        with patch.object(settings, "ENV", "development"), \
+             patch.object(settings, "DEBUG", True), \
+             patch.object(settings, "SKIP_HEADER_CHECK", True), \
+             patch.object(settings, "VISTA_AUTH_BACKEND", "demo"), \
+             patch.object(settings, "PROXY_SHARED_SECRET", None):
+            # No exception expected outside production.
+            settings.validate_production_safety()
+
+    def test_production_with_debug_raises(self):
+        with patch.object(settings, "ENV", "production"), \
+             patch.object(settings, "DEBUG", True), \
+             patch.object(settings, "SKIP_HEADER_CHECK", False), \
+             patch.object(settings, "VISTA_AUTH_BACKEND", "custom"), \
+             patch.object(settings, "PROXY_SHARED_SECRET", "secret"):
+            with pytest.raises(RuntimeError, match="DEBUG=true"):
+                settings.validate_production_safety()
+
+    def test_production_with_skip_header_check_raises(self):
+        with patch.object(settings, "ENV", "production"), \
+             patch.object(settings, "DEBUG", False), \
+             patch.object(settings, "SKIP_HEADER_CHECK", True), \
+             patch.object(settings, "VISTA_AUTH_BACKEND", "custom"), \
+             patch.object(settings, "PROXY_SHARED_SECRET", "secret"):
+            with pytest.raises(RuntimeError, match="SKIP_HEADER_CHECK"):
+                settings.validate_production_safety()
+
+    def test_production_with_demo_backend_raises(self):
+        with patch.object(settings, "ENV", "production"), \
+             patch.object(settings, "DEBUG", False), \
+             patch.object(settings, "SKIP_HEADER_CHECK", False), \
+             patch.object(settings, "VISTA_AUTH_BACKEND", "demo"), \
+             patch.object(settings, "PROXY_SHARED_SECRET", "secret"):
+            with pytest.raises(RuntimeError, match="demo is not allowed"):
+                settings.validate_production_safety()
+
+    def test_production_without_proxy_secret_raises(self):
+        with patch.object(settings, "ENV", "production"), \
+             patch.object(settings, "DEBUG", False), \
+             patch.object(settings, "SKIP_HEADER_CHECK", False), \
+             patch.object(settings, "VISTA_AUTH_BACKEND", "custom"), \
+             patch.object(settings, "PROXY_SHARED_SECRET", None):
+            with pytest.raises(RuntimeError, match="PROXY_SHARED_SECRET"):
+                settings.validate_production_safety()
+
+    def test_production_safe_config_passes(self):
+        with patch.object(settings, "ENV", "production"), \
+             patch.object(settings, "DEBUG", False), \
+             patch.object(settings, "SKIP_HEADER_CHECK", False), \
+             patch.object(settings, "VISTA_AUTH_BACKEND", "custom"), \
+             patch.object(settings, "PROXY_SHARED_SECRET", "super-secret"):
+            settings.validate_production_safety()

--- a/backend/tests/test_auth_backend_hardening.py
+++ b/backend/tests/test_auth_backend_hardening.py
@@ -124,6 +124,7 @@ class TestProductionSafetyValidator:
         with patch.object(settings, "ENV", "production"), \
              patch.object(settings, "DEBUG", True), \
              patch.object(settings, "SKIP_HEADER_CHECK", False), \
+             patch.object(settings, "FAST_TEST_MODE", False), \
              patch.object(settings, "VISTA_AUTH_BACKEND", "custom"), \
              patch.object(settings, "PROXY_SHARED_SECRET", "secret"):
             with pytest.raises(RuntimeError, match="DEBUG=true"):
@@ -133,15 +134,28 @@ class TestProductionSafetyValidator:
         with patch.object(settings, "ENV", "production"), \
              patch.object(settings, "DEBUG", False), \
              patch.object(settings, "SKIP_HEADER_CHECK", True), \
+             patch.object(settings, "FAST_TEST_MODE", False), \
              patch.object(settings, "VISTA_AUTH_BACKEND", "custom"), \
              patch.object(settings, "PROXY_SHARED_SECRET", "secret"):
             with pytest.raises(RuntimeError, match="SKIP_HEADER_CHECK"):
+                settings.validate_production_safety()
+
+    def test_production_with_fast_test_mode_raises(self):
+        """FAST_TEST_MODE=true must not bypass production guards."""
+        with patch.object(settings, "ENV", "production"), \
+             patch.object(settings, "DEBUG", False), \
+             patch.object(settings, "SKIP_HEADER_CHECK", False), \
+             patch.object(settings, "FAST_TEST_MODE", True), \
+             patch.object(settings, "VISTA_AUTH_BACKEND", "custom"), \
+             patch.object(settings, "PROXY_SHARED_SECRET", "secret"):
+            with pytest.raises(RuntimeError, match="FAST_TEST_MODE"):
                 settings.validate_production_safety()
 
     def test_production_with_demo_backend_raises(self):
         with patch.object(settings, "ENV", "production"), \
              patch.object(settings, "DEBUG", False), \
              patch.object(settings, "SKIP_HEADER_CHECK", False), \
+             patch.object(settings, "FAST_TEST_MODE", False), \
              patch.object(settings, "VISTA_AUTH_BACKEND", "demo"), \
              patch.object(settings, "PROXY_SHARED_SECRET", "secret"):
             with pytest.raises(RuntimeError, match="demo is not allowed"):
@@ -151,6 +165,7 @@ class TestProductionSafetyValidator:
         with patch.object(settings, "ENV", "production"), \
              patch.object(settings, "DEBUG", False), \
              patch.object(settings, "SKIP_HEADER_CHECK", False), \
+             patch.object(settings, "FAST_TEST_MODE", False), \
              patch.object(settings, "VISTA_AUTH_BACKEND", "custom"), \
              patch.object(settings, "PROXY_SHARED_SECRET", None):
             with pytest.raises(RuntimeError, match="PROXY_SHARED_SECRET"):
@@ -160,6 +175,7 @@ class TestProductionSafetyValidator:
         with patch.object(settings, "ENV", "production"), \
              patch.object(settings, "DEBUG", False), \
              patch.object(settings, "SKIP_HEADER_CHECK", False), \
+             patch.object(settings, "FAST_TEST_MODE", False), \
              patch.object(settings, "VISTA_AUTH_BACKEND", "custom"), \
              patch.object(settings, "PROXY_SHARED_SECRET", "super-secret"):
             settings.validate_production_safety()

--- a/backend/tests/test_auth_system.py
+++ b/backend/tests/test_auth_system.py
@@ -135,19 +135,37 @@ class TestGroupAuth:
         """Test mock user group membership."""
         with patch.object(settings, 'DEBUG', False):
             with patch.object(settings, 'SKIP_HEADER_CHECK', False):
-                with patch.object(settings, 'MOCK_USER_EMAIL', 'mock@example.com'):
-                    with patch.object(settings, 'MOCK_USER_GROUPS_JSON', '["admin", "users"]'):
-                        assert core_is_user_in_group("mock@example.com", "admin") is True
-                        assert core_is_user_in_group("mock@example.com", "users") is True
-                        assert core_is_user_in_group("mock@example.com", "nonexistent") is False
+                with patch.object(settings, 'VISTA_AUTH_BACKEND', 'demo'):
+                    with patch.object(settings, 'MOCK_USER_EMAIL', 'mock@example.com'):
+                        with patch.object(settings, 'MOCK_USER_GROUPS_JSON', '["admin", "users"]'):
+                            assert core_is_user_in_group("mock@example.com", "admin") is True
+                            assert core_is_user_in_group("mock@example.com", "users") is True
+                            assert core_is_user_in_group("mock@example.com", "nonexistent") is False
 
     def test_case_insensitive_email(self):
         """Test that email comparison is case insensitive."""
         with patch.object(settings, 'DEBUG', False):
             with patch.object(settings, 'SKIP_HEADER_CHECK', False):
-                with patch.object(settings, 'MOCK_USER_EMAIL', 'Mock@Example.COM'):
-                    with patch.object(settings, 'MOCK_USER_GROUPS_JSON', '["admin"]'):
-                        assert core_is_user_in_group("mock@example.com", "admin") is True
+                with patch.object(settings, 'VISTA_AUTH_BACKEND', 'demo'):
+                    with patch.object(settings, 'MOCK_USER_EMAIL', 'Mock@Example.COM'):
+                        with patch.object(settings, 'MOCK_USER_GROUPS_JSON', '["admin"]'):
+                            assert core_is_user_in_group("mock@example.com", "admin") is True
+
+    def test_unconfigured_backend_raises(self):
+        """Without VISTA_AUTH_BACKEND set, checks raise NotImplementedError."""
+        with patch.object(settings, 'DEBUG', False):
+            with patch.object(settings, 'SKIP_HEADER_CHECK', False):
+                with patch.object(settings, 'VISTA_AUTH_BACKEND', None):
+                    with pytest.raises(NotImplementedError):
+                        core_is_user_in_group("admin@example.com", "admin")
+
+    def test_demo_backend_refused_in_production(self):
+        """Demo backend is refused when ENV=production."""
+        with patch.object(settings, 'DEBUG', False):
+            with patch.object(settings, 'SKIP_HEADER_CHECK', False):
+                with patch.object(settings, 'ENV', 'production'):
+                    with patch.object(settings, 'VISTA_AUTH_BACKEND', 'demo'):
+                        assert core_is_user_in_group("admin@example.com", "admin") is False
 
 
 class TestGroupAuthHelper:

--- a/backend/tests/test_group_membership.py
+++ b/backend/tests/test_group_membership.py
@@ -12,6 +12,20 @@ def test_is_user_in_group_debug(monkeypatch):
 def test_is_user_in_group_non_debug_with_groups(monkeypatch):
     monkeypatch.setattr(settings, "DEBUG", False)
     monkeypatch.setattr(settings, "SKIP_HEADER_CHECK", False)
+    monkeypatch.setattr(settings, "VISTA_AUTH_BACKEND", "demo")
+    from core.group_auth_helper import clear_cache
+    clear_cache()
     # Test with dev mapping - user@example.com has project-alpha-group access
     assert is_user_in_group("user@example.com", "project-alpha-group") is True
     assert is_user_in_group("user@example.com", "nonexistent") is False
+
+
+def test_fail_closed_without_auth_backend(monkeypatch):
+    """With no VISTA_AUTH_BACKEND set, group checks raise NotImplementedError."""
+    import pytest
+    from core.group_auth import _check_group_membership
+    monkeypatch.setattr(settings, "DEBUG", False)
+    monkeypatch.setattr(settings, "SKIP_HEADER_CHECK", False)
+    monkeypatch.setattr(settings, "VISTA_AUTH_BACKEND", None)
+    with pytest.raises(NotImplementedError):
+        _check_group_membership("admin@example.com", "admin")

--- a/backend/tests/test_simple_auth.py
+++ b/backend/tests/test_simple_auth.py
@@ -29,37 +29,39 @@ def test_debug_mode_auth():
 
 
 def test_production_mode_auth():
-    """Test group membership in production mode"""
+    """Test group membership in production mode (demo backend)."""
     clear_cache()
-    
+
     # In production mode, should check actual group membership
     with patch.object(settings, 'DEBUG', False):
         with patch.object(settings, 'SKIP_HEADER_CHECK', False):
-            with patch.object(settings, 'MOCK_USER_EMAIL', 'mock@example.com'):
-                with patch.object(settings, 'MOCK_USER_GROUPS_JSON', '["admin", "users"]'):
-                    # Mock user should have admin access
-                    assert is_user_in_group("mock@example.com", "admin") is True
-                    assert is_user_in_group("mock@example.com", "users") is True
-                    assert is_user_in_group("mock@example.com", "nonexistent") is False
-                    
-                    # Unknown user should not have access
-                    assert is_user_in_group("unknown@example.com", "admin") is False
+            with patch.object(settings, 'VISTA_AUTH_BACKEND', 'demo'):
+                with patch.object(settings, 'MOCK_USER_EMAIL', 'mock@example.com'):
+                    with patch.object(settings, 'MOCK_USER_GROUPS_JSON', '["admin", "users"]'):
+                        # Mock user should have admin access
+                        assert is_user_in_group("mock@example.com", "admin") is True
+                        assert is_user_in_group("mock@example.com", "users") is True
+                        assert is_user_in_group("mock@example.com", "nonexistent") is False
+
+                        # Unknown user should not have access
+                        assert is_user_in_group("unknown@example.com", "admin") is False
 
 
 def test_group_membership():
-    """Test group membership checks"""
+    """Test group membership checks against the demo backend."""
     clear_cache()
-    
+
     with patch.object(settings, 'DEBUG', False):
         with patch.object(settings, 'SKIP_HEADER_CHECK', False):
-            # Test admin user (from dev mapping)
-            assert is_user_in_group("admin@example.com", "admin") is True
-            assert is_user_in_group("admin@example.com", "data-scientists") is True
-            assert is_user_in_group("admin@example.com", "nonexistent-group") is False
-            
-            # Test regular user (from dev mapping)
-            assert is_user_in_group("user@example.com", "project-alpha-group") is True
-            assert is_user_in_group("user@example.com", "admin") is False
+            with patch.object(settings, 'VISTA_AUTH_BACKEND', 'demo'):
+                # Test admin user (from dev mapping)
+                assert is_user_in_group("admin@example.com", "admin") is True
+                assert is_user_in_group("admin@example.com", "data-scientists") is True
+                assert is_user_in_group("admin@example.com", "nonexistent-group") is False
+
+                # Test regular user (from dev mapping)
+                assert is_user_in_group("user@example.com", "project-alpha-group") is True
+                assert is_user_in_group("user@example.com", "admin") is False
 
 
 if __name__ == "__main__":

--- a/docs/admin/authentication.md
+++ b/docs/admin/authentication.md
@@ -141,9 +141,21 @@ oauth2-proxy --config oauth2-proxy.cfg
 
 Projects belong to groups (`meta_group_id`). Users must be members of a project's group to access it.
 
+`core.group_auth._check_group_membership` is **fail-closed**: it raises
+`NotImplementedError` until `VISTA_AUTH_BACKEND` is set. Supported values:
+
+- `demo` -- hardcoded example mapping. Development/tests only; refused when `ENV=production`.
+- `custom` -- your real integration (LDAP, OIDC, database, etc.).
+
+On startup, `run_auth_startup_self_test()` verifies that, for non-demo
+backends, the hardcoded demo emails (`admin@example.com`,
+`scientist@example.com`, `user@example.com`) do NOT resolve as members of
+the demo groups. If any do, the app refuses to start.
+
 ### Implementing Group Membership
 
-Edit `backend/core/group_auth.py` and implement `_check_group_membership`:
+Set `VISTA_AUTH_BACKEND=custom`, then edit `backend/core/group_auth.py` and
+replace the `custom` branch of `_check_group_membership`:
 
 ```python
 import requests

--- a/docs/admin/authentication.md
+++ b/docs/admin/authentication.md
@@ -155,9 +155,16 @@ the demo groups. If any do, the app refuses to start.
 ### Implementing Group Membership
 
 Set `VISTA_AUTH_BACKEND=custom`, then edit `backend/core/group_auth.py` and
-replace the `custom` branch of `_check_group_membership`:
+replace the `custom` branch of `_check_group_membership`.
+
+VISTA ships with only `AUTH_SERVER_URL` in `core.config.Settings`. The
+examples below reference additional environment variables (LDAP URL,
+bind DN, API tokens, etc.) that **you must add yourself** -- either as
+new fields on `Settings` or via `os.getenv()`. Do not copy the examples
+verbatim expecting those knobs to already exist.
 
 ```python
+import os
 import requests
 from core.config import settings
 
@@ -167,24 +174,27 @@ def _check_group_membership(user_email: str, group_id: str) -> bool:
     Implement based on your auth system.
     """
     # Example 1: LDAP/Active Directory
+    # Add LDAP_URL, LDAP_BIND_DN, LDAP_BIND_PASSWORD, LDAP_BASE_DN,
+    # LDAP_GROUPS_DN to your environment / Settings class first.
     import ldap
-    conn = ldap.initialize(settings.LDAP_URL)
-    conn.simple_bind_s(settings.LDAP_BIND_DN, settings.LDAP_BIND_PASSWORD)
+    conn = ldap.initialize(os.environ["LDAP_URL"])
+    conn.simple_bind_s(os.environ["LDAP_BIND_DN"], os.environ["LDAP_BIND_PASSWORD"])
     result = conn.search_s(
-        settings.LDAP_BASE_DN,
+        os.environ["LDAP_BASE_DN"],
         ldap.SCOPE_SUBTREE,
-        f"(&(mail={user_email})(memberOf=cn={group_id},{settings.LDAP_GROUPS_DN}))"
+        f"(&(mail={user_email})(memberOf=cn={group_id},{os.environ['LDAP_GROUPS_DN']}))",
     )
     return len(result) > 0
-    
+
     # Example 2: External API
+    # settings.AUTH_SERVER_URL already exists; supply your own token env var.
     response = requests.get(
         f"{settings.AUTH_SERVER_URL}/api/users/{user_email}/groups",
-        headers={"Authorization": f"Bearer {settings.AUTH_API_TOKEN}"}
+        headers={"Authorization": f"Bearer {os.environ['VISTA_AUTH_API_TOKEN']}"},
     )
     user_groups = response.json().get("groups", [])
     return group_id in user_groups
-    
+
     # Example 3: Database
     from core.database import get_db
     # Query user_groups table

--- a/docs/production/proxy-setup.md
+++ b/docs/production/proxy-setup.md
@@ -213,16 +213,29 @@ project's group to access it.
 
 For production, set `VISTA_AUTH_BACKEND=custom`, edit
 `backend/core/group_auth.py`, and replace the `custom` branch of
-`_check_group_membership`:
+`_check_group_membership`.
+
+VISTA ships with `AUTH_SERVER_URL` on `core.config.Settings`. Any
+additional knobs the example below references (e.g. an API token) must
+be added by the integrator -- either as new `Settings` fields or via
+`os.getenv()`. They are not pre-defined.
 
 ```python
+import os
+import requests
+from core.config import settings
+
 def _check_group_membership(user_email: str, group_id: str) -> bool:
     backend = (settings.VISTA_AUTH_BACKEND or "").strip().lower()
     if backend == "custom":
-        # Example: query LDAP
+        # Example: query an external auth service.
+        # VISTA_AUTH_API_TOKEN is an integrator-owned env var; add it
+        # to your deployment environment.
         response = requests.get(
             f"{settings.AUTH_SERVER_URL}/api/user/{user_email}/groups",
-            headers={"Authorization": f"Bearer {settings.AUTH_API_TOKEN}"},
+            headers={
+                "Authorization": f"Bearer {os.environ['VISTA_AUTH_API_TOKEN']}",
+            },
         )
         return group_id in response.json().get("groups", [])
     # ... leave the demo / fallthrough branches intact

--- a/docs/production/proxy-setup.md
+++ b/docs/production/proxy-setup.md
@@ -203,17 +203,37 @@ project's group to access it.
 
 ### Customizing Group Membership
 
-Edit `backend/core/group_auth.py` and replace `_check_group_membership`:
+`core.group_auth._check_group_membership` is **fail-closed** -- it raises
+`NotImplementedError` until you configure a backend. You must set
+`VISTA_AUTH_BACKEND` (see `.env.example`):
+
+- `demo` -- hardcoded example mapping. Development and tests only; refused
+  at startup when `ENV=production`.
+- `custom` -- your real auth integration.
+
+For production, set `VISTA_AUTH_BACKEND=custom`, edit
+`backend/core/group_auth.py`, and replace the `custom` branch of
+`_check_group_membership`:
 
 ```python
 def _check_group_membership(user_email: str, group_id: str) -> bool:
-    # Example: query LDAP
-    response = requests.get(
-        f"{settings.AUTH_SERVER_URL}/api/user/{user_email}/groups",
-        headers={"Authorization": f"Bearer {settings.AUTH_API_TOKEN}"}
-    )
-    return group_id in response.json().get("groups", [])
+    backend = (settings.VISTA_AUTH_BACKEND or "").strip().lower()
+    if backend == "custom":
+        # Example: query LDAP
+        response = requests.get(
+            f"{settings.AUTH_SERVER_URL}/api/user/{user_email}/groups",
+            headers={"Authorization": f"Bearer {settings.AUTH_API_TOKEN}"},
+        )
+        return group_id in response.json().get("groups", [])
+    # ... leave the demo / fallthrough branches intact
 ```
+
+On startup, `run_auth_startup_self_test()` verifies the stub was replaced
+and that the hardcoded demo emails (`admin@example.com`,
+`scientist@example.com`, `user@example.com`) do **not** resolve as members
+of the demo groups. If they do, the app refuses to start -- this catches
+deployments that forgot to replace the helper, or that accidentally named a
+real user after one of the demo emails.
 
 Membership checks are cached for 5 minutes by default (configurable in
 `backend/core/group_auth_helper.py`).
@@ -244,11 +264,13 @@ Membership checks are cached for 5 minutes by default (configurable in
 ## Deployment Checklist
 
 **Backend:**
+- [ ] `ENV=production`
 - [ ] `DEBUG=false`, `SKIP_HEADER_CHECK=false`
+- [ ] `VISTA_AUTH_BACKEND=custom`
 - [ ] `PROXY_SHARED_SECRET` set (matches proxy config)
 - [ ] `alembic upgrade head` run
 - [ ] Production database and S3/MinIO configured
-- [ ] Custom `_check_group_membership` implemented
+- [ ] Custom `_check_group_membership` implemented (startup self-test passes)
 
 **Reverse Proxy:**
 - [ ] OAuth2/SAML/LDAP configured for `/api/` (browser users)


### PR DESCRIPTION
## Summary

Fixes security issue **C1**: the demo group-auth helper shipped as the default, creating a silent prod-bypass risk if an integrator forgot to replace it or if a real user was ever named `admin@example.com`. Combined with the `DEBUG`/`SKIP_HEADER_CHECK` short-circuit, any deployment that flipped one env var became fully open.

- `core.group_auth._check_group_membership` is now **fail-closed**: raises `NotImplementedError` unless `VISTA_AUTH_BACKEND` is explicitly set to `demo` or `custom`. The demo branch is refused when `ENV=production`.
- New `Settings.validate_production_safety()` refuses startup when `ENV=production` with `DEBUG=true`, `SKIP_HEADER_CHECK=true`, `VISTA_AUTH_BACKEND=demo`, or missing `PROXY_SHARED_SECRET`.
- New `run_auth_startup_self_test()` runs in the FastAPI lifespan and refuses to start if the backend is unset, if a `custom` backend still raises `NotImplementedError`, or if any of the hardcoded demo emails (`admin@example.com`, `scientist@example.com`, `user@example.com`) still resolve as members of the demo groups.
- Documentation updated: `.env.example`, `CLAUDE.md`, `docs/production/proxy-setup.md`, `docs/admin/authentication.md`.

## Test plan

- [x] `uv run pytest` — 285 passed
- [x] New `backend/tests/test_auth_backend_hardening.py` (19 tests) covers:
  - fail-closed default when `VISTA_AUTH_BACKEND` unset / unknown / `custom` stub
  - demo backend works outside production, denied in production
  - DEBUG bypass denied in production
  - startup self-test raises on unconfigured / unknown / stub / insecure custom backends
  - production validator raises on `DEBUG`, `SKIP_HEADER_CHECK`, `demo` backend, missing `PROXY_SHARED_SECRET`
- [x] Existing auth tests updated to set `VISTA_AUTH_BACKEND=demo` where they exercise the demo mapping
- [ ] Integrator manual check: set `VISTA_AUTH_BACKEND=custom` on a fresh deployment and confirm startup refuses until the helper is replaced